### PR TITLE
[FEATURE] Broken Links Check (Netlify Deploy)

### DIFF
--- a/.github/workflows/broken_links_check.yml
+++ b/.github/workflows/broken_links_check.yml
@@ -1,0 +1,76 @@
+name: "Broken links check on Preview Deploy"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-preview-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      pull-requests: write
+    if: github.event.issue.pull_request && contains(github.event.comment.body, 'Deploy Preview for') && contains(github.event.comment.body, 'https://deploy-preview')
+
+    steps:
+      - uses: "actions/checkout@v4"
+
+     ################# Parse URL #######################
+
+      - name: 🔎 Parse Deploy URL out of comment body
+        id: parse-url
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          BODY=$(echo "$BODY" | grep -Eo "(http|https)://deploy-preview[a-zA-Z0-9./?=_%:-]*" | sort -u)
+          echo "URL=${BODY}" >> "$GITHUB_OUTPUT"
+
+     ################# Check links #######################
+
+      - name: "🕵️‍♂️ Check preview page for broken links"
+        id: linkcheck
+        continue-on-error: true
+        if:  ${{ startsWith(steps.parse-url.outputs.URL, 'https://deploy-preview') && endsWith(steps.parse-url.outputs.URL, '.netlify.app') }}
+        uses: filiph/linkcheck@3.0.0
+        with:
+          arguments: ${{ steps.parse-url.outputs.URL }} --external --no-connection-failures-as-warnings --skip-file .github/linkcheck-skip.txt
+
+     ################# On Success #######################
+
+      - name: ✅ Add PR Comment if link check passes 
+        if:  steps.linkcheck.outcome == 'success'
+        uses: mshick/add-pr-comment@v2
+        with:
+          allow-repeats: true
+          message: |
+            ✅ No broken links detected!
+
+      - name: ✂️ Remove broken link labels
+        if:  steps.linkcheck.outcome == 'success'
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            broken links
+
+      ################# On Failure #######################
+
+      - name: ❌ Add PR Comment if link check fails
+        if:  steps.linkcheck.outcome != 'success'
+        uses: mshick/add-pr-comment@v2
+        with:
+          allow-repeats: true
+          message: |
+            Hello, thank you for your contribution! 🙏 
+                        
+            It appears that broken links were found in the latest deploy preview page.
+                        
+            Please check [GitHub Actions](https://github.com/${{github.repository}}/commit/${{github.sha}}/checks/${{github.run_id}}) for more details and proceed to review your changes to fix any hyperlinks resulting in error.
+
+            LaraDumps team
+
+      - name: 🏷️ Add PR Labels if link check fails
+        if:  steps.linkcheck.outcome != 'success'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: |
+            broken links

--- a/.github/workflows/linkcheck-skip.txt
+++ b/.github/workflows/linkcheck-skip.txt
@@ -1,0 +1,5 @@
+# These links will be exclude from broken link check perfomred at CI.
+# See https://github.com/marketplace/actions/check-links-with-linkcheck
+
+*twitter.com/*
+https://getcomposer.org


### PR DESCRIPTION
Hi Luan,


This PR adds a GitHub Action to execute a broken link verification when Netlify delivers the "Deploy Preview is ready!" comment.

<img width="1534" height="464" alt="CleanShot 2025-08-24 at 16 18 28@2x" src="https://github.com/user-attachments/assets/69fbbb54-4b2f-4392-a603-1be4763a0dcb" />

The action script will parse the preview URL and run a check on it. If broken links are found, it will mark the PR with an orange label and leave a comment on the same PR indicating the GitHub Action link,

<img width="2482" height="298" alt="CleanShot 2025-08-24 at 15 17 41@2x" src="https://github.com/user-attachments/assets/f41d3008-8e64-412e-98c1-f6dbed5999a8" />

<img width="1942" height="502" alt="CleanShot 2025-08-24 at 15 58 01@2x" src="https://github.com/user-attachments/assets/a9b87c16-7fdf-4d84-a949-91639f3fde5c" />

Similarly, when all links are working, it will remove any broken link label and leave an OK comment.
 
## Ignoring URLs

Some URLs might give a false negative. To ignore them, just add one URL per line in the file `.github/workflows/linkcheck-skip.txt`.

## Dependencies

- [linkcheck](https://github.com/marketplace/actions/check-links-with-linkcheck)


